### PR TITLE
Provide local development SSL certs [WIP]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .proxee
+*.pem

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.proxee

--- a/.proxee.json
+++ b/.proxee.json
@@ -1,5 +1,6 @@
 {
-  "certificate_hostnames": ["localhost"],
+  "certificate_path": "localhost.pem",
+  "key_path": "localhost-key.pem",
   "hosts": {
     "app": "http://localhost:3000",
     "ui": "http://localhost:3001"

--- a/.proxee.json
+++ b/.proxee.json
@@ -1,4 +1,5 @@
 {
+  "certificate_hostnames": ["localhost"],
   "hosts": {
     "app": "http://localhost:3000",
     "ui": "http://localhost:3001"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,16 +29,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bumpalo"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
+
+[[package]]
 name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
+name = "cc"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "cfg-if"
@@ -293,6 +311,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
+name = "js-sys"
+version = "0.3.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,6 +397,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ba99ba6393e2c3734791401b66902d981cb03bf190af674ca69949b6d5fb15"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,6 +443,15 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "pem"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9a3b09a20e374558580a4914d3b7d89bd61b954a5a5e1dcbea98753addb1947"
+dependencies = [
+ "base64",
 ]
 
 [[package]]
@@ -463,6 +508,7 @@ dependencies = [
  "futures",
  "hyper",
  "indexmap",
+ "rcgen",
  "regex",
  "serde",
  "serde_json",
@@ -476,6 +522,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7fa2d386df8533b02184941c76ae2e0d0c1d053f5d43339169d80f21275fc5e"
+dependencies = [
+ "pem",
+ "ring",
+ "time",
+ "yasna",
 ]
 
 [[package]]
@@ -503,6 +561,21 @@ name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
 
 [[package]]
 name = "ryu"
@@ -579,6 +652,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -609,6 +688,16 @@ name = "textwrap"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+
+[[package]]
+name = "time"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
+dependencies = [
+ "libc",
+ "num_threads",
+]
 
 [[package]]
 name = "tokio"
@@ -679,6 +768,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,6 +787,70 @@ checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
  "log",
  "try-lock",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
+
+[[package]]
+name = "web-sys"
+version = "0.3.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -724,3 +883,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "yasna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346d34a236c9d3e5f3b9b74563f238f955bbd05fa0b8b4efa53c130c43982f4c"
+dependencies = [
+ "time",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,9 +510,12 @@ dependencies = [
  "indexmap",
  "rcgen",
  "regex",
+ "rustls-pemfile",
  "serde",
  "serde_json",
+ "tls-listener",
  "tokio",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -578,6 +581,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fbfeb8d0ddb84706bc597a5574ab8912817c52a397f819e5b614e2265206921"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
+dependencies = [
+ "base64",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,6 +612,16 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "serde"
@@ -690,6 +724,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
+name = "thiserror"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "time"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,6 +751,20 @@ checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
 dependencies = [
  "libc",
  "num_threads",
+]
+
+[[package]]
+name = "tls-listener"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42257668593ac35c772fa8bfb4bfd4d357298d5a6b816cb9a4462ec3b7627d26"
+dependencies = [
+ "futures-util",
+ "hyper",
+ "pin-project-lite",
+ "thiserror",
+ "tokio",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -727,6 +795,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a27d5f2b839802bd8267fa19b0530f5a08b9c08cd417976be2a65d130fe1c11b"
+dependencies = [
+ "rustls",
+ "tokio",
+ "webpki",
 ]
 
 [[package]]
@@ -851,6 +930,16 @@ checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ regex = "1.5.4"
 indexmap = { version = "1.8.0", features = ["serde"] }
 colored = "2"
 rcgen = "0.9.2"
+tls-listener = { version = "0.4.0", features = ["hyper-h1", "rustls"] }
+tokio-rustls = "0.23.2"
+rustls-pemfile = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ futures = "0.3.5"
 regex = "1.5.4"
 indexmap = { version = "1.8.0", features = ["serde"] }
 colored = "2"
+rcgen = "0.9.2"

--- a/src/certs.rs
+++ b/src/certs.rs
@@ -1,0 +1,26 @@
+use rcgen::generate_simple_self_signed;
+use std::fs;
+
+pub struct SignedCert {
+    pub certificate: String,
+    pub private_key: String,
+}
+
+pub fn generate_and_save(hostnames: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
+    let result = generate_self_signed_cert(hostnames).unwrap();
+    fs::create_dir_all(".proxee").unwrap();
+    fs::write(".proxee/server.crt", result.certificate).unwrap();
+    fs::write(".proxee/server.key", result.private_key).unwrap();
+    Ok(())
+}
+
+fn generate_self_signed_cert(
+    hostnames: Vec<String>,
+) -> Result<SignedCert, Box<dyn std::error::Error>> {
+    let cert = generate_simple_self_signed(hostnames).unwrap();
+    let result = SignedCert {
+        private_key: cert.serialize_private_key_pem(),
+        certificate: cert.serialize_pem().unwrap(),
+    };
+    return Ok(result);
+}

--- a/src/certs.rs
+++ b/src/certs.rs
@@ -1,23 +1,16 @@
-use rcgen::generate_simple_self_signed;
 use rustls_pemfile::{certs, pkcs8_private_keys};
 use std::fs;
 use std::io::BufReader;
+use std::sync::Arc;
+use tokio_rustls::rustls::{Certificate, PrivateKey, ServerConfig};
 
-pub struct SignedCert {
-    pub certificate: String,
-    pub private_key: String,
-}
-
-pub fn tls_acceptor() -> tokio_rustls::TlsAcceptor {
-    use std::sync::Arc;
-    use tokio_rustls::rustls::{Certificate, PrivateKey, ServerConfig};
-
-    let keys_file = fs::File::open(".proxee/server.key").unwrap();
+pub fn tls_acceptor(key_path: String, cert_path: String) -> tokio_rustls::TlsAcceptor {
+    let keys_file = fs::File::open(key_path).unwrap();
     let mut keys_reader = BufReader::new(keys_file);
     let parsed_keys = pkcs8_private_keys(&mut keys_reader).unwrap();
     let key_vec = parsed_keys.first().unwrap();
 
-    let cert_file = fs::File::open(".proxee/server.crt").unwrap();
+    let cert_file = fs::File::open(cert_path).unwrap();
     let mut cert_reader = BufReader::new(cert_file);
     let parsed_certs = certs(&mut cert_reader).unwrap();
     let cert_vec = parsed_certs.first().unwrap();
@@ -36,21 +29,3 @@ pub fn tls_acceptor() -> tokio_rustls::TlsAcceptor {
     .into()
 }
 
-pub fn generate_and_save(hostnames: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
-    let result = generate_self_signed_cert(hostnames).unwrap();
-    fs::create_dir_all(".proxee").unwrap();
-    fs::write(".proxee/server.crt", result.certificate).unwrap();
-    fs::write(".proxee/server.key", result.private_key).unwrap();
-    Ok(())
-}
-
-fn generate_self_signed_cert(
-    hostnames: Vec<String>,
-) -> Result<SignedCert, Box<dyn std::error::Error>> {
-    let cert = generate_simple_self_signed(hostnames).unwrap();
-    let result = SignedCert {
-        private_key: cert.serialize_private_key_pem(),
-        certificate: cert.serialize_pem().unwrap(),
-    };
-    return Ok(result);
-}

--- a/src/certs.rs
+++ b/src/certs.rs
@@ -1,9 +1,39 @@
 use rcgen::generate_simple_self_signed;
+use rustls_pemfile::{certs, pkcs8_private_keys};
 use std::fs;
+use std::io::BufReader;
 
 pub struct SignedCert {
     pub certificate: String,
     pub private_key: String,
+}
+
+pub fn tls_acceptor() -> tokio_rustls::TlsAcceptor {
+    use std::sync::Arc;
+    use tokio_rustls::rustls::{Certificate, PrivateKey, ServerConfig};
+
+    let keys_file = fs::File::open(".proxee/server.key").unwrap();
+    let mut keys_reader = BufReader::new(keys_file);
+    let parsed_keys = pkcs8_private_keys(&mut keys_reader).unwrap();
+    let key_vec = parsed_keys.first().unwrap();
+
+    let cert_file = fs::File::open(".proxee/server.crt").unwrap();
+    let mut cert_reader = BufReader::new(cert_file);
+    let parsed_certs = certs(&mut cert_reader).unwrap();
+    let cert_vec = parsed_certs.first().unwrap();
+    println!("parsed cert: {:?}", cert_vec);
+
+    let key = PrivateKey(key_vec.clone());
+    let cert = Certificate(cert_vec.clone());
+
+    Arc::new(
+        ServerConfig::builder()
+            .with_safe_defaults()
+            .with_no_client_auth()
+            .with_single_cert(vec![cert], key)
+            .unwrap(),
+    )
+    .into()
 }
 
 pub fn generate_and_save(hostnames: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {

--- a/src/certs.rs
+++ b/src/certs.rs
@@ -14,7 +14,6 @@ pub fn tls_acceptor(key_path: String, cert_path: String) -> tokio_rustls::TlsAcc
     let mut cert_reader = BufReader::new(cert_file);
     let parsed_certs = certs(&mut cert_reader).unwrap();
     let cert_vec = parsed_certs.first().unwrap();
-    println!("parsed cert: {:?}", cert_vec);
 
     let key = PrivateKey(key_vec.clone());
     let cert = Certificate(cert_vec.clone());

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,8 @@ use std::fs;
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Config {
-  pub certificate_hostnames: Vec<String>,
+  pub certificate_path: String,
+  pub key_path: String,
   pub hosts: IndexMap<String, String>,
   pub rules: IndexMap<String, String>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@ use std::fs;
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Config {
+  pub certificate_hostnames: Vec<String>,
   pub hosts: IndexMap<String, String>,
   pub rules: IndexMap<String, String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,16 +9,19 @@ use regex::Regex;
 use std::convert::Infallible;
 use std::result::Result;
 
+mod certs;
 mod config;
 
 #[derive(Subcommand)]
 enum Action {
     /// Starts the server
-   Start {
-    /// Port number to start proxy on
-    #[clap(short, long, default_value_t = 8080)]
-    port: u16,
-   },
+    Start {
+        /// Port number to start proxy on
+        #[clap(short, long, default_value_t = 8080)]
+        port: u16,
+    },
+    /// Self-signs certificates and performs other pre-setup configs
+    Init {},
 }
 
 /// Simple program to greet a person
@@ -52,7 +55,7 @@ async fn proxy_inner(
     // Await the response...
 
     let (parts, body) = req.into_parts();
-    let path: String = parts
+    let _path: String = parts
         .uri
         .path()
         .parse::<String>()
@@ -170,6 +173,10 @@ async fn main() {
         Action::Start { port } => {
             let s = Proxy::new(port).run().await;
             s.unwrap()
+        }
+        Action::Init {} => {
+            let c = config::parse().unwrap();
+            let _generated = certs::generate_and_save(c.certificate_hostnames).unwrap();
         }
     }
 }


### PR DESCRIPTION
This allows a user to use `mkcert` to generate self-signed certificates and add a trusted root CA.

Proxee will use the generated certs via a new configuration and use a new SSL listener to serve SSL connections locally.